### PR TITLE
Added mmap implementation for Windows

### DIFF
--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -17,19 +17,48 @@ import (
 // We keep this map so that we can get back the original handle from the memory address.
 var handleLock sync.Mutex
 var handleMap = map[uintptr]syscall.Handle{}
+var fileMap = map[uintptr]*os.File{}
+
+func openSharedFile(f *os.File) (file *os.File, err error) {
+
+	var access, createmode, sharemode uint32
+	var sa *syscall.SecurityAttributes
+
+	access = syscall.GENERIC_READ
+	sharemode = uint32(syscall.FILE_SHARE_READ | syscall.FILE_SHARE_WRITE | syscall.FILE_SHARE_DELETE)
+	createmode = syscall.OPEN_EXISTING
+	fileName := f.Name()
+
+	pathp, err := syscall.UTF16PtrFromString(fileName)
+	if err != nil {
+		return nil, err
+	}
+
+	h, e := syscall.CreateFile(pathp, access, sharemode, sa, createmode, syscall.FILE_ATTRIBUTE_NORMAL, 0)
+
+	if e != nil {
+		return nil, e
+	}
+	//NewFile does not add finalizer, need to close this manually
+	return os.NewFile(uintptr(h), fileName), nil
+}
 
 func mmap(f *os.File, offset int64, length int) (out []byte, err error) {
 	// Open a file mapping handle.
 	sizelo := uint32(length >> 32)
 	sizehi := uint32(length) & 0xffffffff
-	//h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READWRITE, sizelo, sizehi, nil)
-	h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
+
+	sharedHandle, errno := openSharedFile(f)
+	if errno != nil {
+		return nil, os.NewSyscallError("CreateFile", errno)
+	}
+
+	h, errno := syscall.CreateFileMapping(syscall.Handle(sharedHandle.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
 	if h == 0 {
 		return nil, os.NewSyscallError("CreateFileMapping", errno)
 	}
 
 	// Create the memory map.
-	//addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ | syscall.FILE_MAP_WRITE , 0, 0, uintptr(length))
 	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(length))
 	if addr == 0 {
 		return nil, os.NewSyscallError("MapViewOfFile", errno)
@@ -37,6 +66,7 @@ func mmap(f *os.File, offset int64, length int) (out []byte, err error) {
 
 	handleLock.Lock()
 	handleMap[addr] = h
+	fileMap[addr] = sharedHandle
 	handleLock.Unlock()
 
 	// Convert to a byte array.
@@ -70,6 +100,16 @@ func munmap(b []byte) (err error) {
 
 	e := syscall.CloseHandle(syscall.Handle(handle))
 	return os.NewSyscallError("CloseHandle", e)
+
+	file, ok := fileMap[addr]
+	if !ok {
+		// should be impossible; we would've seen the error above
+		return errors.New("unknown base address")
+	}
+	delete(fileMap, addr)
+
+	e = file.Close()
+	return errors.New("Close File" + e.Error())
 
 	return nil
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -1,8 +1,10 @@
 package tsm1
 
 import (
+	"errors"
 	"os"
 	"reflect"
+	"sync"
 	"syscall"
 	"unsafe"
 )
@@ -11,25 +13,31 @@ import (
 // Based on: https://github.com/edsrzf/mmap-go
 // Based on: https://github.com/boltdb/bolt/bolt_windows.go
 // Ref: https://groups.google.com/forum/#!topic/golang-nuts/g0nLwQI9www
+
+// We keep this map so that we can get back the original handle from the memory address.
+var handleLock sync.Mutex
+var handleMap = map[uintptr]syscall.Handle{}
+
 func mmap(f *os.File, offset int64, length int) (out []byte, err error) {
 	// Open a file mapping handle.
 	sizelo := uint32(length >> 32)
 	sizehi := uint32(length) & 0xffffffff
+	//h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READWRITE, sizelo, sizehi, nil)
 	h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
 	if h == 0 {
 		return nil, os.NewSyscallError("CreateFileMapping", errno)
 	}
 
 	// Create the memory map.
+	//addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ | syscall.FILE_MAP_WRITE , 0, 0, uintptr(length))
 	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(length))
 	if addr == 0 {
 		return nil, os.NewSyscallError("MapViewOfFile", errno)
 	}
 
-	// Close mapping handle.
-	if err := syscall.CloseHandle(syscall.Handle(h)); err != nil {
-		return nil, os.NewSyscallError("CloseHandle", err)
-	}
+	handleLock.Lock()
+	handleMap[addr] = h
+	handleLock.Unlock()
 
 	// Convert to a byte array.
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&out))
@@ -45,9 +53,23 @@ func mmap(f *os.File, offset int64, length int) (out []byte, err error) {
 // Based on: https://github.com/boltdb/bolt/bolt_windows.go
 func munmap(b []byte) (err error) {
 
+	handleLock.Lock()
+	defer handleLock.Unlock()
+
 	addr := (uintptr)(unsafe.Pointer(&b[0]))
 	if err := syscall.UnmapViewOfFile(addr); err != nil {
 		return os.NewSyscallError("UnmapViewOfFile", err)
 	}
+
+	handle, ok := handleMap[addr]
+	if !ok {
+		// should be impossible; we would've seen the error above
+		return errors.New("unknown base address")
+	}
+	delete(handleMap, addr)
+
+	e := syscall.CloseHandle(syscall.Handle(handle))
+	return os.NewSyscallError("CloseHandle", e)
+
 	return nil
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -2,19 +2,16 @@ package tsm1
 
 import (
 	"os"
+	"reflect"
 	"syscall"
 	"unsafe"
-	"reflect"
 )
-
-// maxMapSize represents the largest mmap size supported by Bolt. 
-const maxMapSize = 0xFFFFFFFFFFFF // 256TB 
 
 // mmap implementation for Windows
 // Based on: https://github.com/edsrzf/mmap-go
 // Based on: https://github.com/boltdb/bolt/bolt_windows.go
 // Ref: https://groups.google.com/forum/#!topic/golang-nuts/g0nLwQI9www
-func mmap(f *os.File, offset int64, length int) (out []byte,err error) {
+func mmap(f *os.File, offset int64, length int) (out []byte, err error) {
 	// Open a file mapping handle.
 	sizelo := uint32(length >> 32)
 	sizehi := uint32(length) & 0xffffffff
@@ -47,7 +44,7 @@ func mmap(f *os.File, offset int64, length int) (out []byte,err error) {
 // Based on: https://github.com/edsrzf/mmap-go
 // Based on: https://github.com/boltdb/bolt/bolt_windows.go
 func munmap(b []byte) (err error) {
-	
+
 	addr := (uintptr)(unsafe.Pointer(&b[0]))
 	if err := syscall.UnmapViewOfFile(addr); err != nil {
 		return os.NewSyscallError("UnmapViewOfFile", err)

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -1,14 +1,56 @@
 package tsm1
 
 import (
-	"fmt"
 	"os"
+	"syscall"
+	"unsafe"
+	"reflect"
 )
 
-func mmap(f *os.File, offset int64, length int) ([]byte, error) {
-	return nil, fmt.Errorf("mmap file not supported windows")
+// maxMapSize represents the largest mmap size supported by Bolt. 
+const maxMapSize = 0xFFFFFFFFFFFF // 256TB 
+
+// mmap implementation for Windows
+// Based on: https://github.com/edsrzf/mmap-go
+// Based on: https://github.com/boltdb/bolt/bolt_windows.go
+// Ref: https://groups.google.com/forum/#!topic/golang-nuts/g0nLwQI9www
+func mmap(f *os.File, offset int64, length int) (out []byte,err error) {
+	// Open a file mapping handle.
+	sizelo := uint32(length >> 32)
+	sizehi := uint32(length) & 0xffffffff
+	h, errno := syscall.CreateFileMapping(syscall.Handle(f.Fd()), nil, syscall.PAGE_READONLY, sizelo, sizehi, nil)
+	if h == 0 {
+		return nil, os.NewSyscallError("CreateFileMapping", errno)
+	}
+
+	// Create the memory map.
+	addr, errno := syscall.MapViewOfFile(h, syscall.FILE_MAP_READ, 0, 0, uintptr(length))
+	if addr == 0 {
+		return nil, os.NewSyscallError("MapViewOfFile", errno)
+	}
+
+	// Close mapping handle.
+	if err := syscall.CloseHandle(syscall.Handle(h)); err != nil {
+		return nil, os.NewSyscallError("CloseHandle", err)
+	}
+
+	// Convert to a byte array.
+	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&out))
+	hdr.Data = uintptr(unsafe.Pointer(addr))
+	hdr.Len = length
+	hdr.Cap = length
+
+	return
 }
 
+// munmap Windows implementation
+// Based on: https://github.com/edsrzf/mmap-go
+// Based on: https://github.com/boltdb/bolt/bolt_windows.go
 func munmap(b []byte) (err error) {
-	return nil, fmt.Errorf("munmap file not supported on windows")
+	
+	addr := (uintptr)(unsafe.Pointer(&b[0]))
+	if err := syscall.UnmapViewOfFile(addr); err != nil {
+		return os.NewSyscallError("UnmapViewOfFile", err)
+	}
+	return nil
 }

--- a/tsdb/engine/tsm1/tsm1.go
+++ b/tsdb/engine/tsm1/tsm1.go
@@ -14,7 +14,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/golang/snappy"
@@ -1971,7 +1970,8 @@ func NewDataFile(f *os.File) (*dataFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	mmap, err := syscall.Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
+	//mmap, err := syscall.Mmap(int(f.Fd()), 0, int(fInfo.Size()), syscall.PROT_READ, syscall.MAP_SHARED|MAP_POPULATE)
+	mmap, err := mmap(f, 0, int(fInfo.Size()))
 	if err != nil {
 		return nil, err
 	}
@@ -2030,7 +2030,7 @@ func (d *dataFile) close() error {
 	if d.mmap == nil {
 		return nil
 	}
-	err := syscall.Munmap(d.mmap)
+	err := munmap(d.mmap)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Trying to fix https://github.com/influxdb/influxdb/issues/4358 

Added mmap implementation for Windows based on MapViewOfFile. Used SliceHeader trick to change the pointer returned by MapViewOfFile to a byte slice. This will not call for any change in rest of tsm.

However I am not sure where this mmap function is called, as go build is still complains about 

```
tsdb\engine\tsm1\tsm1.go:1974: undefined: syscall.Mmap
tsdb\engine\tsm1\tsm1.go:1974: undefined: syscall.PROT_READ
tsdb\engine\tsm1\tsm1.go:1974: undefined: syscall.MAP_SHARED
tsdb\engine\tsm1\tsm1.go:2033: undefined: syscall.Munmap
```
