### PR TITLE
Fix issue preventing build in Windows

### DIFF
--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -10,5 +10,5 @@ func mmap(f *os.File, offset int64, length int) ([]byte, error) {
 }
 
 func munmap(b []byte) (err error) {
-	return nil, fmt.Errorf("munmap file not supported on windows")
+	return fmt.Errorf("munmap file not supported on windows")
 }


### PR DESCRIPTION
Removed nil in line#13 return which was stopping the build in Windows. `src\github.com\influxdb\influxdb\tsdb\engine\tsm1\mmap_windows.go:13: too many arguments to return` issue is fixed.
